### PR TITLE
Missing not equal implementation on class Prefix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 4.3 (unreleased)
 ----------------
 
+- Add __ne__ to the Prefix class.
+  Fix a problem with undoLog/undoInfo filtering in ZODB.UndoLogCompatible
 
 4.2 (2017-04-26)
 ----------------

--- a/src/ZopeUndo/Prefix.py
+++ b/src/ZopeUndo/Prefix.py
@@ -38,6 +38,9 @@ class Prefix(object):
             other_path[-1] = other_path[-1][:pos]
         return other_path[:self.length] == self.path
 
+    def __ne__(self, o):
+        return not self.__eq__(o)
+
     def __repr__(self):
         # makes failing tests easier to read
         return "Prefix('%s')" % '/'.join(self.path)

--- a/src/ZopeUndo/tests/test_prefix.py
+++ b/src/ZopeUndo/tests/test_prefix.py
@@ -21,11 +21,17 @@ class PrefixTest(unittest.TestCase):
 
     def test(self):
         p1 = Prefix("/a/b")
+
+        # test "==" (__eq__) operator
         for equal in ("/a/b", "/a/b/c", "/a/b/c/d"):
             self.assertEqual(p1, equal)
-            self.assertFalse(p1 != equal)
         for notEqual in ("", "/a/c", "/a/bbb", "///"):
             self.assertNotEqual(p1, notEqual)
+
+        # test "!=" (__ne__) operator
+        for equal in ("/a/b", "/a/b/c", "/a/b/c/d"):
+            self.assertFalse(p1 != equal)
+        for notEqual in ("", "/a/c", "/a/bbb", "///"):
             self.assertTrue(p1 != notEqual)
 
         p2 = Prefix("")

--- a/src/ZopeUndo/tests/test_prefix.py
+++ b/src/ZopeUndo/tests/test_prefix.py
@@ -23,10 +23,10 @@ class PrefixTest(unittest.TestCase):
         p1 = Prefix("/a/b")
         for equal in ("/a/b", "/a/b/c", "/a/b/c/d"):
             self.assertEqual(p1, equal)
-        for equal in ("/a/b", "/a/b/c", "/a/b/c/d"):
-            self.assertEqual(p1 != equal, False)
+            self.assertFalse(p1 != equal)
         for notEqual in ("", "/a/c", "/a/bbb", "///"):
             self.assertNotEqual(p1, notEqual)
+            self.assertTrue(p1 != notEqual)
 
         p2 = Prefix("")
         for equal in ("", "/", "/def", "/a/b", "/a/b/c", "/a/b/c/d"):

--- a/src/ZopeUndo/tests/test_prefix.py
+++ b/src/ZopeUndo/tests/test_prefix.py
@@ -23,6 +23,8 @@ class PrefixTest(unittest.TestCase):
         p1 = Prefix("/a/b")
         for equal in ("/a/b", "/a/b/c", "/a/b/c/d"):
             self.assertEqual(p1, equal)
+        for equal in ("/a/b", "/a/b/c", "/a/b/c/d"):
+            self.assertEqual(p1 != equal, False)
         for notEqual in ("", "/a/c", "/a/bbb", "///"):
             self.assertNotEqual(p1, notEqual)
 


### PR DESCRIPTION
The main problem is that here: https://github.com/zopefoundation/ZODB/blob/master/src/ZODB/UndoLogCompatible.py#L31 the comparison between user_name property and Prefix use != operator

If the operator __ne__ is not implemented on Prefix class the above condition is everytime False and all the Undo entries will be filtered out (i.e. the manage_UndoForm view is empty in every folder than root Zope).
